### PR TITLE
feat: Carrier action order

### DIFF
--- a/gameTick.markdown
+++ b/gameTick.markdown
@@ -13,9 +13,9 @@ The game runs in ticks, during a tick the following events happen in order:
 9. Carrier garrison actions are performed.
 10. Combat occurs at contested stars.
 11. If at the end of a galactic cycle:
-11a. Players receive credits from economy and banking.
-11b. Experimentations are performed.
-11c. Carrier upkeep is deducted.
+    1. Players receive credits from economy and banking.
+    2. Experimentation is performed.
+    3. Carrier upkeep is deducted.
 12. Game checks for afk and defeated players.
 13. AI actions are performed.
 14. Research is performed.

--- a/gameTick.markdown
+++ b/gameTick.markdown
@@ -24,3 +24,14 @@ The game runs in ticks, during a tick the following events happen in order:
 17. Time-limited specialists are checked for expiration.
 18. Game checks for a winner.
 19. Intel is logged.
+
+## Carrier Action Order
+
+If multiple carriers perform the same category of action on the same tick at the same star
+(for example, multiple carriers are scheduled to collect),
+the order of actions is resolved according to these rules:
+
+1. The carrier with more ships performs its action first.
+2. If carriers have the same number of ships,
+   the one that traveled the shorter distance from its last waypoint goes first.
+4. If carriers tie in both of the above, the carrier that was built first goes first.


### PR DESCRIPTION
* Add Carrier Action Order section to Game Tick Events, based on the explanation from @Metritutus 
* Render the EOC nested list as a proper nested list

![image](https://github.com/user-attachments/assets/35203f2f-7ebe-478d-b4b0-61a67a4c9647)
